### PR TITLE
apply version-based ordering to downloads and change log

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -113,7 +113,10 @@ declare function app:package-to-list-item($app as element(app), $show-details as
                                 <tr>
                                     <td>Download older versions:</td>
                                     <td>{
-                                        let $versions := $app/other/version 
+                                        let $versions := 
+                                            for $version in $app/other/version 
+                                            order by $version/@version 
+                                            return $version
                                         for $version at $n in $versions
                                         let $download-version-url := concat($repoURL, 'public/', $version/@path)
                                         return
@@ -136,6 +139,7 @@ declare function app:package-to-list-item($app as element(app), $show-details as
                                 for $change in $app/changelog/change
                                 let $version := $change/@version/string()
                                 let $comment := $change/node()
+                                order by $version descending
                                 return
                                     <tr>
                                         <td>{$version}</td>


### PR DESCRIPTION
This was motivated by seeing the unordered list of old versions of eXide available for download from http://demo.exist-db.org/exist/apps/public-repo/packages/eXide.html: 1.0.7, 2.0.1, 2.0, 1.0.13, 1.0.8, 1.0.15, 1.0.14, 1.0.9, 1.0.11, 1.0.12, 1.0.10.  I realize that the sorting in this commit is naive - treating the entire version as a string, instead of parsing and sorting each number.  But this is a step forward.
