### PR TITLE
Fix failed lookup of packages compatible with older versions of eXist

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -44,8 +44,9 @@ declare function app:view-package($node as node(), $model as map(*), $mode as xs
                 response:redirect-to(xs:anyURI($info-url))
         (: view current package info :)
         else
-            let $compatible-xar := app:find-version($app, $procVersion, (), (), (), ())
-            let $package := $app[@path eq $compatible-xar]
+            let $app-versions := ($app, $app/other/version)
+            let $compatible-xar := app:find-version($app-versions, $procVersion, (), (), (), ())
+            let $package := $app-versions[@path eq $compatible-xar]
             let $show-details := true()
             return
                 app:package-to-list-item($package, $show-details)

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -49,7 +49,16 @@ declare function app:view-package($node as node(), $model as map(*), $mode as xs
             let $package := $app-versions[@path eq $compatible-xar]
             let $show-details := true()
             return
-                app:package-to-list-item($package, $show-details)
+                if (exists($package)) then
+                    app:package-to-list-item($package, $show-details)
+                else
+                    (
+                        response:set-status-code(404),
+                        if (exists($app)) then
+                            <li class="package text-warning">Package {$abbrev} requires a newer version of eXist.</li>
+                        else
+                            <li class="package text-warning">No package {$abbrev} is available.</li>
+                    )
 };
 
 declare function app:package-to-list-item($app as element(app), $show-details as xs:boolean) {

--- a/modules/find.xql
+++ b/modules/find.xql
@@ -21,7 +21,8 @@ let $app :=
         collection($config:app-root || "/public")//app[name eq $name]
     else
         collection($config:app-root || "/public")//app[abbrev eq $abbrev]
-let $compatible-xar := app:find-version($app | $app/other/version, $procVersion, $version, $semVer, $minVersion, $maxVersion)
+let $app-versions := ($app, $app/other/version)
+let $compatible-xar := app:find-version($app-versions, $procVersion, $version, $semVer, $minVersion, $maxVersion)
 return
     if ($compatible-xar) then
         let $rel-public :=
@@ -31,7 +32,7 @@ return
                 "public/"
         return
             if ($info) then
-                <found>{$app}</found>
+                <found>{$compatible-xar}</found>
             else if ($zip) then
                 response:redirect-to(xs:anyURI($rel-public || $compatible-xar || ".zip"))
             else

--- a/modules/scan.xql
+++ b/modules/scan.xql
@@ -47,7 +47,7 @@ declare function scanrepo:process($apps as element(app)*) {
                         let $n := tokenize($older/version, "\.") ! xs:int(analyze-string(., "(\d+)")//fn:group[1])
                         order by $n[1], $n[2], $n[3]
                         return
-                            <version version="{$older/version}">{$older/@path}</version>
+                            <version version="{$older/version}">{$older/@path, $older/requires}</version>
                     )
                 }
                 </other>


### PR DESCRIPTION
As reported on exist-open (see https://markmail.org/message/wi3oawlljhbdxa7q), a user running eXist 4.5.0 is trying to install a version of monex compatible with his version of eXist, but the public-repo is telling him the only version of monex available requires eXist 5.0.0. In other words, http://demo.exist-db.org/exist/apps/public-repo/packages/monex.html?eXist-db-min-version=4.5.0 is returning a 400 error.

Investigating this report, I discovered that when a package(s) are published, the public-repo app discarded eXist version requirements for all older versions of a package. The only version requirements it preserved were those for the newest version of a package. As a result, when older eXist clients requested a package, the public repo told them no compatible packages were available. In addition, certain endpoints didn't even look for older versions.

With this PR, when a package is published, eXist version requirements for all versions of the package are preserved. Now, when a client requests compatible versions, older versions of the package are included in the search for compatible versions. 

 In addition, in the `/packages/{abbrev}.html` endpoint, a 400 error was raised and an ugly XQuery error message displayed if the package could not be found or if a compatible version could not be found. This PR provides a proper 404 page explaining which condition caused it.