### PR TITLE
Hotfixes to prevent timeout, fix bugs; prepare v0.7.2

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,4 +4,4 @@
 #
 
 project.name=public-repo
-project.version=0.7.1
+project.version=0.7.2

--- a/modules/view.xql
+++ b/modules/view.xql
@@ -7,7 +7,7 @@ import module namespace app="http://exist-db.org/xquery/app" at "app.xql";
 
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 
-declare option exist:timeout "40000";
+declare option exist:timeout "300000";
 
 declare option output:method "html5";
 declare option output:media-type "text/html";

--- a/repo.xml
+++ b/repo.xml
@@ -12,6 +12,12 @@
     <finish>post-install.xql</finish>
     <permissions xmlns:repo="http://exist-db.org/xquery/repo" password="repo" user="repo" group="repo" mode="rw-rw-r--"/>
     <changelog>
+        <change version="0.7.2">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Fixed: Display of HTML pages when requesting packages compatible with older versions of eXist.</li>
+                <li>Fixed: Increase timeout to 5 minutes when publishing apps to allow for re-scanning of larger repositories.</li>
+            </ul>
+        </change>
         <change version="0.7.1">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Fixed: Issue preventing users from accessing older versions of packages when the newest release depends on a newer version of eXist.</li>


### PR DESCRIPTION
- Increase timeout to 5 minutes when publishing apps to allow for re-scanning of larger repositories.
- Fix display of HTML pages when requesting packages compatible with older versions of eXist.
- Prepare v0.7.2 hotfix