### PR TITLE
Fix cardinality error

### DIFF
--- a/modules/scan.xql
+++ b/modules/scan.xql
@@ -52,7 +52,7 @@ declare function scanrepo:process($apps as element(app)*) {
                             "sha256",
                             "hex"
                         )
-                        let $n := tokenize($older/version, "\.") ! xs:int(analyze-string(., "(\d+)")//fn:group[1])
+                        let $n := tokenize($older/version, "\.") ! xs:int((analyze-string(., "(\d+)")//fn:group)[1])
                         order by $n[1], $n[2], $n[3]
                         return
                             <version version="{$older/version}">{


### PR DESCRIPTION
A valid semver string like "5.0.0-RC7" would throw a cardinality error. This ensures only the major, minor, and patch components of the semver string are included.