### PR TITLE
WIP: Adopt semver.xq library to fix version sorting & querying woes

### DIFF
--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -3,5 +3,5 @@
     <title>eXist-db Public Application Repository</title>
     <dependency processor="http://exist-db.org" semver-min="3.5.0"/>
     <dependency package="http://expath.org/ns/crypto" semver-min="0.5"/>
-    <dependency package="http://exist-db.org/xquery/semver" semver-min="2.2.0-SNAPSHOT"/>
+    <dependency package="http://exist-db.org/xquery/semver-xq" semver-min="2.2.0"/>
 </package>

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -3,4 +3,5 @@
     <title>eXist-db Public Application Repository</title>
     <dependency processor="http://exist-db.org" semver-min="3.5.0"/>
     <dependency package="http://expath.org/ns/crypto" semver-min="0.5"/>
+    <dependency package="http://exist-db.org/xquery/semver" semver-min="2.2.0-SNAPSHOT"/>
 </package>

--- a/modules/find.xql
+++ b/modules/find.xql
@@ -5,7 +5,6 @@ import module namespace response="http://exist-db.org/xquery/response";
 
 import module namespace app="http://exist-db.org/xquery/app" at "app.xql";
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
-import module namespace scanrepo="http://exist-db.org/xquery/admin/scanrepo" at "scan.xql";
 
 let $abbrev := request:get-parameter("abbrev", ())
 let $name := request:get-parameter("name", ())

--- a/modules/index.xql
+++ b/modules/index.xql
@@ -1,9 +1,0 @@
-xquery version "1.0";
-
-declare option exist:serialize "method=xhtml media-type=text/html";
-
-<html>
-    <body>
-        <h1>Demo App</h1>
-    </body>
-</html>

--- a/modules/list.xql
+++ b/modules/list.xql
@@ -4,6 +4,7 @@ declare namespace list="http://exist-db.org/apps/public-repo/list";
 declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
+import module namespace semver = "http://exist-db.org/xquery/semver";
 
 declare option output:method "xml";
 declare option output:media-type "application/xml";
@@ -18,22 +19,12 @@ declare variable $list:DEFAULT_VERSION := "2.2.0";
 
 declare function list:is-newer-or-same($version1 as xs:string, $version2 as xs:string?) {
     empty($version2) or
-        list:check-version($version1, $version2, function($v1, $v2) { $v1 >= $v2 })
+        semver:ge($version1, $version2, true())
 };
 
 declare function list:is-older-or-same($version1 as xs:string, $version2 as xs:string?) {
     empty($version2) or
-        list:check-version($version1, $version2, function($v1, $v2) { $v1 <= $v2 })
-};
-
-declare function list:version-to-number($version as xs:string) as xs:int {
-    let $ana := analyze-string($version, "(\d+)\.(\d+)\.(\d+)-?(.*)")
-    return
-        sum(($ana//fn:group[@nr="1"] * 1000000, $ana//fn:group[@nr="2"] * 1000, $ana//fn:group[@nr="3"]))
-};
-
-declare function list:check-version($version1 as xs:string, $version2 as xs:string, $check as function(*)) {
-    $check(list:version-to-number($version1), list:version-to-number($version2))
+        semver:le($version1, $version2, true())
 };
 
 declare function list:get-app($app as element(), $version as xs:string) {

--- a/repo.xml
+++ b/repo.xml
@@ -12,6 +12,12 @@
     <finish>post-install.xql</finish>
     <permissions xmlns:repo="http://exist-db.org/xquery/repo" password="repo" user="repo" group="repo" mode="rw-rw-r--"/>
     <changelog>
+        <change version="1.0.0">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>New: Full SemVer 2.0 compliance, backward compatible with most previous package version strings</li>
+                <li>Breaking: New dependency on semver.xq library</li>
+            </ul>
+        </change>
         <change version="0.8.4">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Fixed: Handling for semantic versioning strings with prerelease and build metadata fragments containing numbers</li>


### PR DESCRIPTION
This PR aims to fix https://github.com/eXist-db/public-repo/issues/33, using an approach discussed on this week's Community Call. 

The PR adds a new dependency to the public repo: https://github.com/eXist-db/semver.xq, a pure XQuery 3.1 library for parsing, serializing, sorting, and comparing SemVer 2.0 version strings. Beyond my initial creation, what we needed was an additional function for coercing invalid version strings into valid SemVer 2.0 version strings, and @adamretter has kindly contributed this; he also adapted my tests into proper xqsuite format, and prepared the library as a mavenized EXPath package. Many thanks, Adam! 

With the coercion function ready, I performed the surgery on the public repo app, replacing as little code as possible to begin using the semver library where it counts: identifying the newest version of an app when we publish a new xar(s), and handling version requests from clients accurately,  flexibly, and predictably. 

Further testing is needed on both the semver library and this PR. I have been testing with a full local copy of the exist-db.org public repo collection of xars. 