### PR TITLE
Fix sorting of version strings

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -182,10 +182,7 @@ declare function app:package-to-list-item($app as element(app), $version as xs:s
                                 <tr>
                                     <td>Download older versions:</td>
                                     <td>{
-                                        let $versions := 
-                                            for $version in $app/other/version 
-                                            order by $version/@version 
-                                            return $version
+                                        let $versions := reverse($app/other/version)
                                         for $version at $n in $versions
                                         let $download-version-url := concat($repoURL, "public/", $version/@path)
                                         return

--- a/modules/scan.xql
+++ b/modules/scan.xql
@@ -32,10 +32,11 @@ declare function scanrepo:process($apps as element(app)*) {
                 map:entry("semver", semver:coerce(.) => semver:serialize()), 
                 map:entry("version", .)
             ))
+        let $sorted-semvers := semver:sort($version-maps?semver) => reverse()
         let $sorted-versions := 
-            for $version in $version-maps
-            order by semver:sort($version?semver) descending
-            return $version?version/..
+            for $semver in $sorted-semvers
+            return
+                $version-maps[?semver eq $semver]?version/..
         let $newest-version := $sorted-versions => head()
         let $older-versions := $sorted-versions => tail()
         let $abbrevs := distinct-values($app/abbrev)

--- a/repo.xml
+++ b/repo.xml
@@ -12,6 +12,11 @@
     <finish>post-install.xql</finish>
     <permissions xmlns:repo="http://exist-db.org/xquery/repo" password="repo" user="repo" group="repo" mode="rw-rw-r--"/>
     <changelog>
+        <change version="1.0.1">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Fixed: Sorting of app versions</li>
+            </ul>
+        </change>
         <change version="1.0.0">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>New: Full SemVer 2.0 compliance, backward compatible with most previous package version strings</li>


### PR DESCRIPTION
In public-repo 1.0.0, my work implmenting SemVer-based sorting of apps by version was not fully baked.

The new semver.xq library's `semver:sort()` function does correctly sort version `1.0.10` as higher than `1.0.2`, for example.

I erred in using this function in an `order by` clause of a FLWOR to perform SemVer ordering, because the function only returns a sequence of strings, so the actual ordering will end up being string-based instead of SemVer-based. Since my code used this faulty approach, public-repo v1.0.0's listings of versions showed sorting anomalies like the screenshot below.

This PR fixes this problem - by first sorting the version strings using `semver:sort()`, then mapping this ordering over to the apps. With this PR, eXide versions are now sorted as expected.

Before the PR:

> ![Screen Shot 2019-08-11 at 12 20 57 AM](https://user-images.githubusercontent.com/59118/62829829-6c88b100-bbd0-11e9-98c4-25b74fa4aa2a.png)

After the PR:

> ![Screen Shot 2019-08-11 at 12 37 58 AM](https://user-images.githubusercontent.com/59118/62829833-727e9200-bbd0-11e9-840d-3f2a2c1de1e1.png)

Also, I found another place in the UI where we were applying string sorting to versions, and we now trust the versions to be ordered correctly:

Before the PR:

> ![Screen Shot 2019-08-11 at 12 54 32 AM](https://user-images.githubusercontent.com/59118/62829927-ace92e80-bbd2-11e9-85bb-86bf630e3248.png)

After the PR:

> ![Screen Shot 2019-08-11 at 12 54 19 AM](https://user-images.githubusercontent.com/59118/62829930-b2467900-bbd2-11e9-8d69-b32b205e60d5.png)

There's still room for improvement in the UI for showing change logs, where we apply string sorting to try to show the most "recent" change at the top of the list. That can come another day ;)