### PR TITLE
Account for semver.xq’s dependency on eXist 4.7.0+

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,4 +4,4 @@
 #
 
 project.name=public-repo
-project.version=1.0.1
+project.version=1.0.2

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/public-repo" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>eXist-db Public Application Repository</title>
-    <dependency processor="http://exist-db.org" semver-min="3.5.0"/>
-    <dependency package="http://expath.org/ns/crypto" semver-min="0.5"/>
+    <dependency processor="http://exist-db.org" semver-min="4.7.0"/>
+    <dependency package="http://expath.org/ns/crypto" semver-min="0.7"/>
     <dependency package="http://exist-db.org/xquery/semver-xq" semver-min="2.2.1"/>
 </package>

--- a/repo.xml
+++ b/repo.xml
@@ -12,6 +12,11 @@
     <finish>post-install.xql</finish>
     <permissions xmlns:repo="http://exist-db.org/xquery/repo" password="repo" user="repo" group="repo" mode="rw-rw-r--"/>
     <changelog>
+        <change version="1.0.2">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Fixed: Dependency on semver.xq library actually imposed a new requirement on eXist 4.7.0+</li>
+            </ul>
+        </change>
         <change version="1.0.1">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Fixed: Sorting of app versions</li>


### PR DESCRIPTION
- The expath-pkg.xml file says has long said this app is compatible with eXist 3.5.0 or newer, but the dependency on the semver-xq package introduced in public-repo 1.0.0, actually raises the minimum version required to a newer version of eXist: eXist 4.7.0. 
- Also raised the crypto library dependency to 0.7, the latest version compatible with 4.7.0.