### PR TITLE
Fix find.xql’s redirect when eXist is behind proxy

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -1,4 +1,4 @@
-xquery version "1.0";
+xquery version "3.1";
 
 import module namespace login="http://exist-db.org/xquery/login" at "resource:org/exist/xquery/modules/persistentlogin/login.xql";
 
@@ -7,6 +7,15 @@ declare variable $exist:resource external;
 declare variable $exist:controller external;
 declare variable $exist:prefix external;
 declare variable $exist:root external;
+
+declare variable $app-root-absolute-url := 
+    (request:get-header("X-Forwarded-Proto"), request:get-scheme())[1] 
+    || "://"
+    || (request:get-header("X-Forwarded-Server"), request:get-server-name())[1]
+    || request:get-context-path()
+    || $exist:prefix
+    || $exist:controller
+;
 
 login:set-user("org.exist.public-repo.login", (), false()),
 
@@ -89,7 +98,9 @@ else if (contains($exist:path, "/public/") and ends-with($exist:resource, ".zip"
 
 else if ($exist:path eq "/find" or ends-with($exist:resource, ".zip")) then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-        <forward url="modules/find.xql"/>
+        <forward url="modules/find.xql">
+            <add-parameter name="app-root-absolute-url" value="{$app-root-absolute-url}"/>
+        </forward>
     </dispatch>
 
 else if ($exist:resource eq "feed.xml") then


### PR DESCRIPTION
When eXist is behind a proxy, the `/find` endpoint's `response:redirect-to()` use of a relative URL (e.g., `../public`) can the 302 redirect to generate an incorrect `Location` header. For example, if the proxy talks to eXist over HTTP, eXist's `response:redirect-to()` will construct a `Location` header in the 302 using HTTP—even if the client request to the proxy uses HTTPS. This can cause an HTTPS connection to the server to be downgraded to an HTTP connection, which can in turn cause clients to reject the request. For example, with public-repo 1.0.2 installed on the server, the following command will fail in a local eXist client:

```xquery
xquery version "3.1";

let $package-name := "http://www.functx.com"
let $find-endpoint := "https://exist-db.org/exist/apps/public-repo/find"
return
    repo:install-and-deploy($package-name, $find-endpoint)
```

Here's what happens:

1. The client's `repo:install-and-deploy` function triggers `org.exist.repo.Deployment.installAndDeploy` to make a request to the server's `/find` endpoint at `https://exist-db.org/exist/apps/public-repo/find?name=http://www.functx.com` - an HTTPS request
2. The server returns a 302 status and a `Location: http://exist-db.org/exist/apps/public-repo/public/functx-1.0.xar` response header - which instructs the client to make a downgraded HTTP request
3. The client's `org.eclipse.jetty.security.SecurityHandler.handle` rejects the HTTP downgrade
4. The client's `org.exist.repo` doesn't realize that the request was rejected, so it writes a 0-byte file to the temp directory and tries to expand the file
5. The query returns the following error:
    > experr:EXPATH00 Missing descriptor from package: file:///var/folders/j8/k8hn66_942d9t877btw7_xn00000gp/T/exist-db-temp-file-manager-6495906069643524550/exist-db-temp-2222882736343473276.tmp [at line 6, column 5, source: xquery version "3.1"; let $package-name := "http://www.functx.com" let $find-endpoint := "https://exist-db.org/exist/apps/public-repo/find" return repo:install-and-deploy($package-name, $find-endpoint)]

Note: This PR fixes requests sent to the server's `public-repo/find` endpoint, but does not fix requests to the commonly used `public-repo/modules/find.xql`. The latter URL actually *never* should have been used, given the structure of the `controller.xql` file - but given the lack of documentation or misunderstandings, this endpoint spread. Thus, this PR will be accompanied by changes to the documentation and other apps which reference the anachronistic `modules/find.xql` endpoint. To be clear, this PR doesn't change the behavior of `modules/find.xql`, so if that endpoint is working for anyone, it'll continue working here. For example, changing the code sample above to reference `http://exist-db.org/exist/apps/public-repo/modules/find.xql` will still work! The PR only fixes problems for people whose public-repo apps are behind proxies—so especially helps in the case of HSTS-enabled domains.