### PR TITLE
Prepare release of v2.1.0

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,4 +4,4 @@
 #
 
 project.name=public-repo
-project.version=2.0.0
+project.version=2.1.0

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/public-repo" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>eXist-db Public Application Repository</title>
-    <dependency processor="http://exist-db.org" semver-min="5.0.0"/>
+    <dependency processor="http://exist-db.org" semver-min="5.3.0"/>
     <dependency package="http://exist-db.org/xquery/semver-xq" semver-min="2.2.1"/>
     <dependency package="http://exist-db.org/apps/shared" semver-min="0.9.1"/>
     <dependency package="http://exist-db.org/html-templating" semver-min="1.0.2"/>

--- a/repo.xml
+++ b/repo.xml
@@ -12,6 +12,16 @@
     <finish>post-install.xq</finish>
     <permissions password="repo" user="repo" group="repo" mode="rwxr-xr-x"/>
     <changelog>
+        <change version="2.1.0">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>New: Minimum required version of eXist is 5.3.0.</li>
+                <li>New: Drop ".html" from all routes (redirect old-style links).</li>
+                <li>New: Simplify templates, add base URL to each page.</li>
+                <li>New: Allow publishing packages by any member of the repo group.</li>
+                <li>Fixed: Sorting of package versions.</li>
+                <li>Fixed: Allow publishing packages via curl again.</li>
+            </ul>
+        </change>
         <change version="2.0.0">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>IMPORTANT: You must first run the upgrade script in https://github.com/eXist-db/public-repo/blob/master/modules/upgrade-to-v2-storage.xq before installing v2!</li>

--- a/repo.xml
+++ b/repo.xml
@@ -15,11 +15,14 @@
         <change version="2.1.0">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>New: Minimum required version of eXist is 5.3.0.</li>
-                <li>New: Drop ".html" from all routes (redirect old-style links).</li>
-                <li>New: Simplify templates, add base URL to each page.</li>
                 <li>New: Allow publishing packages by any member of the repo group.</li>
-                <li>Fixed: Sorting of package versions.</li>
+                <li>New: Simplify templates, add base URL to each page.</li>
+                <li>New: Drop ".html" from all routes (redirect old-style links).</li>
+                <li>New: Templates are rendered by HTML-templating library (>= 1.0.2)</li>
+                <li>Fixed: Allow retrieval of packages over HTTPS.</li>
                 <li>Fixed: Allow publishing packages via curl again.</li>
+                <li>Fixed: Sorting of package versions.</li>
+                <li>Fixed: Permissions of log files and metadata.</li>
             </ul>
         </change>
         <change version="2.0.0">

--- a/repo.xml
+++ b/repo.xml
@@ -14,15 +14,15 @@
     <changelog>
         <change version="2.1.0">
             <ul xmlns="http://www.w3.org/1999/xhtml">
-                <li>New: Minimum required version of eXist is 5.3.0.</li>
-                <li>New: Allow publishing packages by any member of the repo group.</li>
-                <li>New: Simplify templates, add base URL to each page.</li>
-                <li>New: Drop ".html" from all routes (redirect old-style links).</li>
-                <li>New: Templates are rendered by HTML-templating library (>= 1.0.2)</li>
-                <li>Fixed: Allow retrieval of packages over HTTPS.</li>
-                <li>Fixed: Allow publishing packages via curl again.</li>
-                <li>Fixed: Sorting of package versions.</li>
-                <li>Fixed: Permissions of log files and metadata.</li>
+                <li>New: Minimum required version of eXist is 5.3.0. - <a href="https://github.com/eXist-db/public-repo/pull/67">#67</a></li>
+                <li>New: Allow publishing packages by any member of the repo group. - <a href="https://github.com/eXist-db/public-repo/pull/67">#67</a></li>
+                <li>New: Simplify templates, add base URL to each page. - <a href="https://github.com/eXist-db/public-repo/pull/66">#66</a></li>
+                <li>New: Drop ".html" from all routes (redirect old-style links). - <a href="https://github.com/eXist-db/public-repo/pull/62">#62</a></li>
+                <li>New: Templates are rendered by HTML-templating library (>= 1.0.2) - <a href="https://github.com/eXist-db/public-repo/pull/56">#56</a></li>
+                <li>Fixed: Allow retrieval of packages over HTTPS. - <a href="https://github.com/eXist-db/public-repo/issue/74">#74</a></li>
+                <li>Fixed: Allow publishing packages via curl again. - <a href="https://github.com/eXist-db/public-repo/pull/69">#69</a></li>
+                <li>Fixed: Sorting of package versions. - <a href="https://github.com/eXist-db/public-repo/pull/57">#57</a></li>
+                <li>Fixed: Permissions of log files and metadata. - <a href="https://github.com/eXist-db/public-repo/pull/73">#73</a>, <a href="https://github.com/eXist-db/public-repo/pull/75">#75</a></li>
             </ul>
         </change>
         <change version="2.0.0">


### PR DESCRIPTION
QUESTION

A raise of the minimum required processor version can be regarded a breaking change. 
Should this be a `3.0.0` release instead?

- [x] state correct minimum processor version

CHANGELOG

- [x] add description for #56 
- [x] describe that retrieving packages over HTTPS works #74
- [x] describe permission fixes #75 and #73 
- [x] add links to the relevant PRs, issues