### PR TITLE
[bugfix] allow basic auth on restricted routes

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -19,7 +19,11 @@ declare variable $app-root-absolute-url :=
 ;
 
 declare function local:is-authorized-user() as xs:boolean {
-    let $user := request:get-attribute($config:login-domain || ".user")
+    let $user := (
+        request:get-attribute($config:login-domain || ".user"),
+        sm:id()//sm:username/string()
+    )[1]
+
     return 
         (
             exists($user) and 


### PR DESCRIPTION
IMPORTANT: this should be merged before #70 

In order for publish requests to succeed using BasicAuth the controller needs to accept those request as well.

Updated test command:

```bash
curl \
  -u repo:repo \
  -F 'files[]=@build/public-repo-2.0.0.xar' \
  http://localhost:8080/exist/apps/public-repo/publish
```