### PR TITLE
tighten permissions

### DIFF
--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -76,7 +76,7 @@ declare function config:repo-descriptor() as element(repo:meta) {
 declare function config:repo-permissions() as map(*) { 
     config:repo-descriptor()/repo:permissions ! 
         map { 
-            "user": ./@user/string(), 
+            "owner": ./@user/string(), 
             "group": ./@group/string(),
             "mode": ./@mode/string()
         }

--- a/modules/db-utility.xqm
+++ b/modules/db-utility.xqm
@@ -30,7 +30,7 @@ function dbu:ensure-collection($path as xs:string) as xs:string {
  : will throw an error if the current user does not have the appropriate rights
  :
  : @param $path xs:string
- : @param $permissions map(xs:string, xs:string) user, group, mode
+ : @param $permissions map(xs:string, xs:string) with "owner", "group", "mode"
  : @returns the path that was entered
  :)
 declare
@@ -60,18 +60,15 @@ function dbu:set-repo-permissions ($resource-or-collection as xs:string) as xs:s
  : will throw an error, if the current user does not have the appropriate rights
  :
  : @param $resource-or-collection xs:string
- : @param $permissions map(xs:string, xs:string) with "user", "group", "mode"
+ : @param $permissions map(xs:string, xs:string) with "owner", "group", "mode"
  : @returns the path that was entered
  :)
 declare 
 function dbu:set-permissions ($resource-or-collection as xs:string, $permissions as map(*)) as xs:string {
-    let $set := (
-        sm:chown($resource-or-collection, $permissions?owner),
-        sm:chgrp($resource-or-collection, $permissions?group),
-        sm:chmod(xs:anyURI($resource-or-collection), $permissions?mode)
-    )
-
-    return $resource-or-collection
+    sm:chown($resource-or-collection, $permissions?owner),
+    sm:chgrp($resource-or-collection, $permissions?group),
+    sm:chmod(xs:anyURI($resource-or-collection), $permissions?mode),
+    $resource-or-collection
 };
 
 declare 

--- a/modules/db-utility.xqm
+++ b/modules/db-utility.xqm
@@ -1,0 +1,96 @@
+xquery version "3.1";
+
+module namespace dbu="http://exist-db.org/xquery/utility/db";
+
+import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
+
+declare variable $dbu:default-permissions := config:repo-permissions();
+
+(:~
+ : create collection(s) if they do not exist
+ : any newly created collection will have the package-permissions set
+ : will throw an error if the current user does not have the appropriate rights
+ :
+ : @param $path xs:string
+ : @returns the path that was entered
+ :)
+declare
+function dbu:ensure-collection($path as xs:string) as xs:string {
+    if (xmldb:collection-available($path))
+    then $path
+    else
+        tokenize($path, "/")
+        => tail() 
+        => fold-left("", dbu:create-collection-with-repo-permissions#2)
+};
+
+(:~
+ : create collection(s) if they do not exist
+ : any newly created collection will have the permissions given in the second parameter
+ : will throw an error if the current user does not have the appropriate rights
+ :
+ : @param $path xs:string
+ : @param $permissions map(xs:string, xs:string) user, group, mode
+ : @returns the path that was entered
+ :)
+declare
+function dbu:ensure-collection($path as xs:string, $permissions as map(*)) as xs:string {
+    if (xmldb:collection-available($path))
+    then $path
+    else
+        tokenize($path, "/")
+        => tail() 
+        => fold-left("", dbu:create-collection(?, ?, $permissions))
+};
+
+(:~
+ : set owner, group and mode for a collection or resource to package defaults
+ : will throw an error, if the current user does not have the appropriate rights
+ :
+ : @param $resource-or-collection xs:string
+ : @returns the path that was entered
+ :)
+declare 
+function dbu:set-repo-permissions ($resource-or-collection as xs:string) as xs:string {
+    dbu:set-permissions($resource-or-collection, $dbu:default-permissions)
+};
+
+(:~
+ : set owner, group and mode for a collection or resource
+ : will throw an error, if the current user does not have the appropriate rights
+ :
+ : @param $resource-or-collection xs:string
+ : @param $permissions map(xs:string, xs:string) with "user", "group", "mode"
+ : @returns the path that was entered
+ :)
+declare 
+function dbu:set-permissions ($resource-or-collection as xs:string, $permissions as map(*)) as xs:string {
+    let $set := (
+        sm:chown($resource-or-collection, $permissions?owner),
+        sm:chgrp($resource-or-collection, $permissions?group),
+        sm:chmod(xs:anyURI($resource-or-collection), $permissions?mode)
+    )
+
+    return $resource-or-collection
+};
+
+declare 
+    %private
+function dbu:create-collection-with-repo-permissions ($collection as xs:string, $next as xs:string) as xs:string {
+    if (xmldb:collection-available(concat($collection, '/', $next)))
+    then concat($collection, '/', $next)
+    else
+        xmldb:create-collection($collection, $next)
+        => dbu:set-repo-permissions()
+};
+
+
+declare 
+    %private
+function dbu:create-collection ($collection as xs:string, $next as xs:string, $permissions as map(*)) as xs:string {
+    if (xmldb:collection-available(concat($collection, '/', $next)))
+    then concat($collection, '/', $next)
+    else
+        xmldb:create-collection($collection, $next)
+        => dbu:set-permissions($permissions)
+};

--- a/repo.xml
+++ b/repo.xml
@@ -10,7 +10,7 @@
     <target>public-repo</target>
     <prepare/>
     <finish>post-install.xq</finish>
-    <permissions password="repo" user="repo" group="repo" mode="rwxrwxr-x"/>
+    <permissions password="repo" user="repo" group="repo" mode="rwxr-xr-x"/>
     <changelog>
         <change version="2.0.0">
             <ul xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
- add DB utility module
- allow public downloads, tighten security

Before this PR is applied there is the possibility of a GET request for a package binary to fail.
This is because clients will connect as guest by default.
If this get package event is the first one to be logged on this day the attempt to create a new log file will fail because "guest" is not allowed to do so.