### PR TITLE
Reinstate support for eXist-db 4.x.x

### DIFF
--- a/modules/get-package.xq
+++ b/modules/get-package.xq
@@ -55,7 +55,7 @@ return
         let $log := local:log-get-package-event($xar-filename)
         return
             if ($wants-zip) then
-                let $entry := <entry type="binary" method="store" name="/{$xar-filename}" strip-prefix="false">{$xar}</entry>
+                let $entry := <entry type="binary" method="store" name="/{$xar-filename}">{$xar}</entry>
                 let $zip := compression:zip($entry, false())
                 return
                     response:stream-binary($zip, "application/zip")

--- a/modules/get-package.xq
+++ b/modules/get-package.xq
@@ -11,6 +11,7 @@ xquery version "3.1";
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
 import module namespace log="http://exist-db.org/xquery/app/log" at "log.xqm";
 
+declare namespace compression="http://exist-db.org/xquery/compression";
 declare namespace request="http://exist-db.org/xquery/request";
 declare namespace response="http://exist-db.org/xquery/response";
 declare namespace util="http://exist-db.org/xquery/util";
@@ -40,9 +41,10 @@ declare function local:log-package-not-found-event($filename as xs:string) as em
 
 
 let $filename := request:get-parameter("filename", ())
+let $wants-zip as xs:boolean := ends-with($filename, ".zip")
 let $xar-filename :=
     (: strip .zip from resource name :)
-    if (ends-with($filename, ".zip")) then
+    if ($wants-zip) then
         replace($filename, ".zip$", "")
     else
         $filename
@@ -52,7 +54,13 @@ return
         let $xar := util:binary-doc($config:packages-col || "/" || $xar-filename)
         let $log := local:log-get-package-event($xar-filename)
         return
-            response:stream-binary($xar, "application/zip")
+            if ($wants-zip) then
+                let $entry := <entry type="binary" method="store" name="/{$xar-filename}" strip-prefix="false">{$xar}</entry>
+                let $zip := compression:zip($entry, false())
+                return
+                    response:stream-binary($zip, "application/zip")
+            else
+                response:stream-binary($xar, "application/zip")
     else
         (
             response:set-status-code(404),


### PR DESCRIPTION
The eXist-db 4.x.x build process requires the public-repo to deliver a Zip file containing the Xar file. This was working in the past. However, it now looks like support for eXist-db 4.x.x was accidentally removed through two refactorings:

1. https://github.com/eXist-db/public-repo/commit/90eb6bb9f50df93ba6473a2d866fb2ae2f89d7b8#diff-bc346eefb44d6303a883aca1f15e3f0e68895c005bfa330f2ea00b7bf2cc70f0
2. https://github.com/eXist-db/public-repo/commit/b65a476d16148e5bc7bc6b13bf7d6b70124a5385#diff-bc346eefb44d6303a883aca1f15e3f0e68895c005bfa330f2ea00b7bf2cc70f0L1

This PR reinstates support for eXist-db 4.x.x.