### PR TITLE
Support EXPath Package SemVer templates

### DIFF
--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -2,7 +2,7 @@
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/public-repo" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>eXist-db Public Application Repository</title>
     <dependency processor="http://exist-db.org" semver-min="5.3.0"/>
-    <dependency package="http://exist-db.org/xquery/semver-xq" semver-min="2.2.1"/>
+    <dependency package="http://exist-db.org/xquery/semver-xq" semver-min="2.4.0"/>
     <dependency package="http://exist-db.org/apps/shared" semver-min="0.9.1"/>
-    <dependency package="http://exist-db.org/html-templating" semver-min="1.0.2"/>
+    <dependency package="http://exist-db.org/html-templating" semver-min="1.1.0"/>
 </package>


### PR DESCRIPTION
Fixes https://github.com/eXist-db/public-repo/issues/72

For example, take [odd-serializer v2.0.0](https://ci.de.dariah.eu/exist-repo/public/odd-serializer-2.0.0.xar), a package that registers the following dependency on eXist:

```xml
<dependency processor="http://exist-db.org" semver-min="4.6.1" semver-max="5"/>
```

Here, the `@semver-max` attribute is a "SemVer template," as defined in the EXPath Package spec [here](http://expath.org/spec/pkg#pkgdep):

> We use only the syntax of SemVer, and define in addition the format of a SemVer template as being either a SemVer version number or a subpart of it (i.e. only the major version, or the major and the minor versions, or the major, the minor and the patch version). For instance 1.9 is a valid SemVer template (because it does not have any patch number), while 1.9.0 and 1.9.23 are actual version numbers compatible with this template.

Thus, the dependency element above expresses a range greater than or equal to version 4.6.1 and less than version 6. 

Before this PR, the public-repo did not recognize EXPath Package SemVer templates, so it coerced `5` into `5.0.0` and would not offer this package in response to requests for packages compatible with, say, eXist 5.4.1.

Indeed, the server at dariah.eu offers this package when requesting packages that satisfy a dependency on eXist 4.6.1 but not 5.4.1:

- https://ci.de.dariah.eu/exist-repo/packages/odd-serializer.html?eXist-db-min-version=4.6.1
- https://ci.de.dariah.eu/exist-repo/packages/odd-serializer.html?eXist-db-min-version=5.4.1

Here's a screenshot showing the server's response to the latter request:

> <img width="1090" alt="Screenshot 2022-12-31 at 18 40 32" src="https://user-images.githubusercontent.com/59118/210157682-8637f3ab-4fc4-4d68-86af-1cff7917fec1.png">

With this PR, the public-repo resolves packages that declare their dependencies on eXist using EXPath Package SemVer templates. 

To test, install odd-serializer v2.0.0 into your test instance of public-repo running this PR (ensuring you're also running https://github.com/eXist-db/semver.xq/pull/18 or a forthcoming release containing this PR merged), and the following requests will show the version as available:

- http://localhost:8080/exist/apps/public-repo/packages/odd-serializer?eXist-db-min-version=5.4.1
- http://localhost:8080/exist/apps/public-repo/find?abbrev=odd-serializer&processor=5.4.1

Here's a screenshot showing an instance running this PR's code:

> <img width="1134" alt="Screenshot 2022-12-31 at 18 40 33" src="https://user-images.githubusercontent.com/59118/210157690-8883c1b0-b736-4497-a051-854839c4e8be.png">

See previous discussion in https://github.com/expath/expath-pkg-java/issues/11.

~~**Do not merge** until https://github.com/eXist-db/semver.xq/pull/18 is merged and semver.xq v2.4.0 is released with that PR and published.~~