### PR TITLE
Refactor with semver.xq v3

### DIFF
--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -2,7 +2,7 @@
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/public-repo" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>eXist-db Public Application Repository</title>
     <dependency processor="http://exist-db.org" semver-min="5.3.0"/>
-    <dependency package="http://exist-db.org/xquery/semver-xq" semver-min="2.4.0"/>
+    <dependency package="http://exist-db.org/xquery/semver-xq" semver-min="3.0.0"/>
     <dependency package="http://exist-db.org/apps/shared" semver-min="0.9.1"/>
     <dependency package="http://exist-db.org/html-templating" semver-min="1.1.0"/>
 </package>

--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -216,7 +216,7 @@ declare function app:view-package($node as node(), $model as map(*), $mode as xs
             (: view current package info :)
             else
                 let $packages := $package-group//package
-                let $compatible-packages := versions:find-compatible-packages($packages, $procVersion)
+                let $compatible-packages := versions:get-packages-satisfying-exist-version($packages, $procVersion)
                 let $incompatible-packages := $packages except $compatible-packages
                 let $show-details := true()
                 return

--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -446,7 +446,7 @@ declare function app:requires-to-english($requires as element()) {
             if (semver:validate-expath-package-semver-template($requires/@semver-max)) then
                 concat("earlier than ", semver:serialize-parsed(semver:resolve-expath-package-semver-template-max($requires/@semver-max)))
             else
-                $requires/@semver-max || "or earlier"
+                $requires/@semver-max || " or earlier"
         )
     else if ($requires/@semver-min) then
         concat(
@@ -463,7 +463,7 @@ declare function app:requires-to-english($requires as element()) {
             if (semver:validate-expath-package-semver-template($requires/@semver-max)) then
                 concat("earlier than ", semver:serialize-parsed(semver:resolve-expath-package-semver-template-max($requires/@semver-max)))
             else
-                $requires/@semver-min || "or earlier"
+                $requires/@semver-min || " or earlier"
         )
     else
         " version " || $config:default-exist-version

--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -352,7 +352,7 @@ declare function app:package-group-to-list-item($package-group as element(packag
                                             let $download-version-url := concat($repoURL, "public/", $package/@path)
                                             return
                                                 <li>
-                                                    <a href="{$download-version-url}">{$package/@path/string()}</a>
+                                                    <a href="{$download-version-url}">{ $package/version/string() }</a>
                                                 </li>,
                                                 
                                             (: show links to any other version of the package that is compatible with the requested version of eXist, 

--- a/modules/find.xq
+++ b/modules/find.xq
@@ -1,9 +1,18 @@
 xquery version "3.1";
 
 (:~
- : Respond to eXist build requests for packages using various identifier and version number criteria
+ : Respond to eXist build requests for packages by their package descriptor's abbrev or name 
+ : attribute, matching either (1) a minimum eXist version expressed as a SemVer version, or 
+ : (2) an EXPath Package version attributes (`version`, `semver`, `semver-min`, and `semver-max`).
  :
- : The info parameter can be used for troubleshooting
+ : The parameter name `version` is retained for backward compatibility, even though it's 
+ : `versions` in the EXPath Package spec.
+ :
+ : The `info` parameter can be used for troubleshooting.
+ :
+ : The `zip` parameter forces the EXPath Package to be returned with a .xar.zip file extension.
+ :
+ : @see http://expath.org/spec/pkg
  :)
 
 import module namespace app="http://exist-db.org/xquery/app" at "app.xqm";
@@ -16,7 +25,7 @@ declare namespace response="http://exist-db.org/xquery/response";
 let $abbrev := request:get-parameter("abbrev", ())
 let $name := request:get-parameter("name", ())
 let $exist-version-semver := request:get-parameter("processor", $config:default-exist-version)
-let $version := request:get-parameter("version", ())
+let $versions := request:get-parameter("version", ())
 let $semver := request:get-parameter("semver", ())
 let $semver-min := request:get-parameter("semver-min", ())
 let $semver-max := request:get-parameter("semver-max", ())
@@ -24,25 +33,29 @@ let $zip := request:get-parameter("zip", ())
 let $info := request:get-parameter("info", ())
 let $app-root-absolute-url := request:get-parameter("app-root-absolute-url", ())
 
-let $package-group :=
+let $packages :=
     if ($name) then
-        doc($config:package-groups-doc)//package-group[name eq $name]
+        doc($config:package-groups-doc)//package-group[name eq $name]//package
     else
-        doc($config:package-groups-doc)//package-group[abbrev eq $abbrev]
+        doc($config:package-groups-doc)//package-group[abbrev eq $abbrev]//package
 
-let $newest-compatible-package := versions:find-newest-compatible-package($package-group//package, $exist-version-semver, $version, $semver, $semver-min, $semver-max)
+let $package := 
+    if (exists($versions) or exists($semver) or exists($semver-min) or exists($semver-max)) then
+        versions:get-newest-package-satisfying-version-attributes($packages, $versions, $semver, $semver-min, $semver-max)
+    else
+        versions:get-newest-package-satisfying-exist-version($packages, $exist-version-semver)
 
 return
-    if ($newest-compatible-package) then
+    if ($package) then
         (: TODO shouldn't we get $abs-public from $config? - joewiz :)
         let $abs-public := $app-root-absolute-url || "/public/"
-        let $xar-filename := $newest-compatible-package/@path
+        let $xar-filename := $package/@path
         return
             if ($info) then
                 element found {
-                    $newest-compatible-package/@sha256, 
-                    $newest-compatible-package/version ! attribute version {.},
-                    $newest-compatible-package/@path
+                    $package/@sha256, 
+                    $package/version ! attribute version {.},
+                    $package/@path
                 }
             else if ($zip) then
                 app:redirect-to($abs-public || $xar-filename || ".zip")

--- a/modules/list.xq
+++ b/modules/list.xq
@@ -20,16 +20,12 @@ declare option output:method "xml";
 declare option output:media-type "application/xml";
 
 let $exist-version := request:get-parameter("version", $config:default-exist-version)
-let $exist-version-semver := 
-    if (semver:validate($exist-version)) then
-        $exist-version
-    else
-        $config:default-exist-version
+let $exist-version-semver := semver:parse($exist-version, true()) => semver:serialize-parsed()
 return
     element apps { 
         attribute version { $exist-version-semver },
         for $package-group in doc($config:package-groups-doc)//package-group
-        let $compatible-packages := versions:find-compatible-packages($package-group//package, $exist-version-semver)
+        let $compatible-packages := versions:get-packages-satisfying-exist-version($package-group//package, $exist-version-semver)
         return
             if (exists($compatible-packages)) then
                 let $newest-package := head($compatible-packages)

--- a/modules/versions.xqm
+++ b/modules/versions.xqm
@@ -1,152 +1,90 @@
 xquery version "3.1";
 
 (:~
- : A library module for finding packages by version number criteria
+ : A library module for finding packages by EXPath Package dependency version attributes 
+ : or eXist version
  :)
 
 module namespace versions="http://exist-db.org/apps/public-repo/versions";
 
 import module namespace semver="http://exist-db.org/xquery/semver";
 
-(:~
- : Find all packages compatible with a specific version of eXist (or higher)
- :)
-declare function versions:find-compatible-packages(
-    $packages as element(package)*, 
-    $exist-version-semver as xs:string
-) as element(package)* {
-    versions:find-compatible-packages($packages, $exist-version-semver, (), (), (), ())
-};
 
 (:~
- : Find all packages compatible with a version of eXist meeting various version criteria
- :
- : TODO: find packages with version, semver, or min/max-version attributes to test those conditions - joewiz
+ : Get all packages satisfying EXPath Package dependency version attributes
  :)
-declare function versions:find-compatible-packages(
+declare function versions:get-packages-satisfying-version-attributes(
     $packages as element(package)*,
-    $exist-version-semver as xs:string, 
-    $version as xs:string?, 
+    $versions as xs:string?, 
     $semver as xs:string?, 
     $semver-min as xs:string?, 
     $semver-max as xs:string?
 ) as element(package)* {
-    if ($semver) then
-        versions:find-version($packages, $semver, $semver)
-    else if ($version) then
-        $packages[version = $version]
-    else if ($semver-min and $semver-max) then
-        versions:find-version($packages, $semver-min, $semver-max)
-    else if (exists($exist-version-semver)) then
-        versions:find-packages-satisfying-exist-version-requirements($packages, $exist-version-semver)
-    else
-        ()
+    $packages[
+        semver:satisfies-expath-package-dependency-versioning-attributes(
+            ./version,
+            $versions,
+            $semver,
+            $semver-min,
+            $semver-max
+        )
+    ]
+    => versions:sort-packages()
 };
 
 (:~
- : Find the newest version of packages compatible with a specific version of eXist (or higher)
+ : Get the newest version of a package satisfying EXPath Package dependency version attributes
  :)
-declare function versions:find-newest-compatible-package(
-    $packages as element(package)*, 
-    $exist-version-semver as xs:string
-) as element(package)? {
-    versions:find-newest-compatible-package($packages, $exist-version-semver, (), (), (), ())
-};
-
-(:~
- : Find the newest version of packages compatible with a version of eXist meeting various version criteria
- :)
-declare function versions:find-newest-compatible-package(
+declare function versions:get-newest-package-satisfying-version-attributes(
     $packages as element(package)*,
-    $exist-version-semver as xs:string, 
-    $version as xs:string?, 
+    $versions as xs:string?, 
     $semver as xs:string?, 
-    $min-version as xs:string?, 
-    $max-version as xs:string?
+    $semver-min as xs:string?, 
+    $semver-max as xs:string?
 ) as element(package)? {
-    versions:find-compatible-packages($packages, $exist-version-semver, $version, $semver, $min-version, $max-version)
+    $packages
+    => versions:get-packages-satisfying-version-attributes($versions, $semver, $semver-min, $semver-max)
     => head()
 };
 
-declare
-    %private
-function versions:find-version($packages as element(package)*, $minVersion as xs:string?, $maxVersion as xs:string?) {
-    let $minVersion := if ($minVersion) then $minVersion else "0"
-    let $maxVersion := if ($maxVersion) then $maxVersion else "9999"
-    return
-        versions:find-version($packages, $minVersion, $maxVersion, ())
-};
-
-declare 
-    %private
-function versions:find-version($packages as element(package)*, $minVersion as xs:string, $maxVersion as xs:string, $newest as element()?) {
-    if (empty($packages)) then
-        $newest
-    else
-        let $package := head($packages)
-        let $packageVersion := ($package/version, $package/@version)[1]
-        let $newestVersion := ($newest/version, $newest/@version)[1]
-        let $newer :=
-            if (
-                (
-                    empty($newest) or 
-                    semver:ge($packageVersion, $newestVersion, true())
-                ) and
-                semver:ge($packageVersion, $minVersion, true()) and
-                semver:le($packageVersion, $maxVersion, true())
-            ) then
-                $package
-            else
-                $newest
-        return
-            versions:find-version(tail($packages), $minVersion, $maxVersion, $newer)
-};
-
 (:~
- : Find packages whose eXist version requirements meet the client's eXist version
- : 
- : @deprecated As of 2.1.3, use the private function versions:find-packages-satisfying-exist-version-requirements#2
- :)
-declare function versions:find-packages-satisfying-exist-version-requirements(
-    $packages as element(package)*,
-    $exist-version-semver as xs:string,
-    $min-version as xs:string?, 
-    $max-version as xs:string?
-) as element(package)* {
-    versions:find-packages-satisfying-exist-version-requirements($packages, $exist-version-semver)
-};
-
-(:~
- : Find packages whose eXist version requirements meet the client's eXist version
+ : Find all packages compatible with a specific version of eXist (or higher)
  : 
  : For example, via app.xqm or list.xq, a client may request the subset of a package's
  : releases that are compatible with eXist 5.3.0. The function examines each release's
  : eXist dependency declarations (if present) and returns all matching packages.
  :)
-declare %private function versions:find-packages-satisfying-exist-version-requirements(
-    $packages as element(package)*,
-    $exist-version-semver as xs:string
+declare function versions:get-packages-satisfying-exist-version(
+    $packages as element(package)*, 
+    $exist-version as xs:string
 ) as element(package)* {
-    for $package in $packages
-    let $satisfies-semver-min-requirement := 
-        if (exists($package/requires/@semver-min)) then
-            semver:ge-parsed(
-                semver:parse($exist-version-semver, true()), 
-                semver:resolve-if-expath-package-server-template-else-parse($package/requires/@semver-min, "min", true())
-            )
-        else
-            true()
-    let $satisfies-semver-max-requirement := 
-        if (exists($package/requires/@semver-max)) then
-            semver:lt-parsed(
-                semver:parse($exist-version-semver, true()), 
-                semver:resolve-if-expath-package-server-template-else-parse($package/requires/@semver-max, "max", true())
-            )
-        else
-            true()
-    return
-        if ($satisfies-semver-min-requirement and $satisfies-semver-max-requirement) then
-            $package
-        else
-            ()
+    $packages[
+        semver:satisfies-expath-package-dependency-versioning-attributes(
+            $exist-version,
+            ./requires/@versions,
+            ./requires/@semver,
+            ./requires/@semver-min,
+            ./requires/@semver-max
+        )
+    ]
+    => versions:sort-packages()
+};
+
+(:~
+ : Find the newest version of packages compatible with a specific version of eXist (or higher)
+ :)
+declare function versions:get-newest-package-satisfying-exist-version(
+    $packages as element(package)*, 
+    $exist-version-semver as xs:string
+) as element(package)? {
+    $packages
+    => versions:get-packages-satisfying-exist-version($exist-version-semver)
+    => head()
+};
+
+(:~
+ : Sort packages by version
+ :)
+declare function versions:sort-packages($packages as element(package)*) {
+    semver:sort($packages, function($package) { $package/version }, true())
 };


### PR DESCRIPTION
My PR https://github.com/eXist-db/semver.xq/pull/26 introduces new functions for checking if a version satisfies EXPath Package dependency versioning attributes, as defined in http://expath.org/spec/pkg#pkgdep.

This PR adopts these new functions in modules/versions.xqm. 

It also ensures that the "find" endpoint can use all version attributes for finding packages:

- http://localhost:8080/exist/apps/public-repo/find?abbrev=eXide&processor=5.0.0
- http://localhost:8080/exist/apps/public-repo/find?abbrev=eXide&version=2.4.7
- http://localhost:8080/exist/apps/public-repo/find?abbrev=eXide&semver=3
- http://localhost:8080/exist/apps/public-repo/find?abbrev=eXide&semver-min=2&semver-max=3

Because of the changes to the public functions in modules/versions.xqm, this PR should be considered a breaking change, and thus the release containing this PR should be a major version - 3.0.0.

~~**NOTE: Do not merge** or change draft status until is https://github.com/eXist-db/semver.xq/pull/26 merged and published in a new major version of semver.xq.~~