### PR TITLE
[bugfix] Packages w/o explicit eXist dependency are presumed compatible with eXist >=2.2.0

### DIFF
--- a/modules/versions.xqm
+++ b/modules/versions.xqm
@@ -66,6 +66,8 @@ declare function versions:get-packages-satisfying-exist-version(
             ./requires/@semver-min,
             ./requires/@semver-max
         )
+        or 
+        empty(./requires)
     ]
     => versions:sort-packages()
 };


### PR DESCRIPTION
Before v3.0.0, public-repo presumed that packages without an explicit eXist dependency were compatible with eXist 2.2.0 or higher. See https://github.com/eXist-db/public-repo/blob/6c833c4b4bcfb8d6b20d07375ff265a48682fc76/modules/versions.xqm#L119-L152.

With v3.0.0, this presumption was inadvertently dropped, leading public-repo to raise an error when requesting information about a package that contained releases without an explicit eXist dependency. 

This PR restores this presumption. 

A hotfix has been applied to the exist-db.org public-repo server. A view that previously triggered the error is https://exist-db.org/exist/apps/public-repo/packages/public-repo?eXist-db-min-version=5.3.0 - due to the presence of releases before 0.8.0 when an explicit eXist dependency was added to this package.