### PR TITLE
add config option to exclude statistics by server

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -186,6 +186,12 @@ else if (request:get-method() = ("GET", "POST") and $exist:path eq "/admin") the
             <forward url="{$exist:controller}/modules/view.xq">
                 <set-header name="Cache-Control" value="no-cache"/>
                 <add-parameter name="base-url" value="{$app-root-absolute-url}"/>
+                {
+                    if (request:get-server-name() = $config:exclude-statistics-server-names) then
+                        ()
+                    else
+                        <add-parameter name="include-statistics" value="true"/>
+                }
             </forward>
         </view>
     </dispatch>

--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -54,6 +54,10 @@ declare variable $config:raw-packages-doc-name := "raw-packages.xml";
 declare variable $config:package-groups-doc := $config:metadata-col || "/" || $config:package-groups-doc-name;
 declare variable $config:raw-packages-doc := $config:metadata-col || "/" || $config:raw-packages-doc-name;
 
+(: Statistics can be expensive to calculate. Add the server name of an instance you wish to exclude
+ : calculation of. :)
+declare variable $config:exclude-statistics-server-names := ("exist-db.org");
+
 (: The default version number here is assumed when a client does not send a version parameter.
    It is set to 2.2.0 because this version was the last one known to work with most older packages
    before packages began to declare their version constraints in their package metadata.

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -8,7 +8,7 @@
     </div>
     <div class="row">
         <div class="col-md-8">
-            <div>
+            <div data-template="templates:if-parameter-set" data-template-param="include-statistics">
                 <h2>Statistics</h2>
                 <h3>Top 5 packages</h3>
                 <ol data-template="app:load-get-package-logs-for-admin-table" data-template-top-n="5">


### PR DESCRIPTION
The calculation of statistics on the admin page is expensive given the current approach and the size of collected statistics on exist-db.org.

Before this PR, excluding the generation of statistics was performed manually on exist-db.org by commenting out the statistics div. It had to be done each time the app was upgraded.

This PR adds a configuration variable in modules/config.xqm, `$config:exclude-statistics-server-names`. On instances with a server name in this sequence, the statistics will be excluded. By default, now, exist-db.org is in this list. 

This saves us the work of commenting out the statistics each time we upgrade the app.

If in the future we improve the calculation of statistics, we could remove this facility. But this is a short term fix to the problem of ensuring exist-db.org doesn't calculate statistics.