### PR TITLE
fix: change wording back to repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# EXPath Package Registry
+# EXPath Package Repository
 
-eXist-db EXPath Package Registry (public-repo)
+eXist-db EXPath Package Repository (public-repo)
 
 This application allows an eXist-db instance to host a repository of applications and libraries stored in the [EXPath Package format](https://expath.org/spec/pkg).
 
@@ -15,7 +15,7 @@ The application:
 - Allows administrators to log in, upload new packages, and refresh the package metadata
 - Allows administrators to log in and see some download statistics
 
-Other eXist-db clients can browse available packages via Dashboard > Package Manager. By default, eXist-db's Dashboard > Package Manager is configured to access the eXist-db EXPath Package Registry at https://exist-db.org/exist/apps/public-repo.
+Other eXist-db clients can browse available packages via Dashboard > Package Manager. By default, eXist-db's Dashboard > Package Manager is configured to access the eXist-db EXPath Package Repository at https://exist-db.org/exist/apps/public-repo.
 
 # Installation
 

--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xdb="http://exist-db.org/ant" default="all" name="Expath Package Registry">
+<project xmlns:xdb="http://exist-db.org/ant" default="all" name="Expath Package Repository">
     <property file="local.build.properties" />
     <property file="build.properties" />
     <property name="build" value="./build" />

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/public-repo" abbrev="@project.name@" version="@project.version@" spec="1.0">
-    <title>EXPath Package Registry</title>
+    <title>EXPath Package Repository</title>
     <dependency processor="http://exist-db.org" semver-min="6.0.0"/>
     <dependency package="http://exist-db.org/xquery/semver-xq" semver-min="3.0.0"/>
     <dependency package="http://exist-db.org/html-templating" semver-min="1.2.1"/>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "public-repo",
   "version": "4.0.0",
-  "description": "Expath Package Registry",
+  "description": "EXPath Package Repository",
   "directories": {
     "test": "test"
   },

--- a/post-install.xq
+++ b/post-install.xq
@@ -36,9 +36,9 @@ declare variable $logs-xconf :=
 
 declare variable $settings :=
     <settings>
-        <title>EXPath Package Registry</title>
+        <title>EXPath Package Repository</title>
         <description>
-            This is a registry of EXPath packages which can be installed into any compatible processor.
+            This is a repository of EXPath packages which can be installed into any compatible processor.
         </description>
         <featured>abbrev</featured>
     </settings>

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <html data-template="lib:resolve-apps" data-template-abbrev="dashboard, eXide, fundocs, exist-documentation, demo, monex">
     <head>
-        <title>EXPath Package Registry</title>
+        <title>EXPath Package Repository</title>
         <base data-template="app:base-url" />
         <link rel="shortcut icon" href="resources/images/exist_icon_16x16.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/test/cypress/e2e/admin_spec.cy.js
+++ b/test/cypress/e2e/admin_spec.cy.js
@@ -42,5 +42,4 @@ describe('admin page', () => {
           .click()
         cy.url().should('not.include', '/admin')
     })
-
 })

--- a/test/cypress/e2e/index_spec.cy.js
+++ b/test/cypress/e2e/index_spec.cy.js
@@ -11,7 +11,7 @@ describe('landing page', () => {
     })
 
     it('should have the default main title', () => {
-        cy.get('h1.hero').contains('EXPath Package Registry')
+        cy.get('h1.hero').contains('EXPath Package Repository')
     })
 
     it('should have an Installation section', () => {


### PR DESCRIPTION
In a previous community call a majority was in favour of keeping the terminology at "repository" at least for the foreseeable future.