### PR TITLE
fix: use response:stream-binary#3 for eXist 7.x compatibility (#104)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
        fail-fast: false
        matrix:
-        # created with 7.0.0-SNAPSHOT, 6.3.0
-         exist-version: [latest, 6.0.0, release]
+         exist-version: [latest, 7.0.0, 6.0.0, release]
          java-version: [8, 21]
          exclude:
            - exist-version: release
@@ -22,6 +21,8 @@ jobs:
            - exist-version: 6.0.0
              java-version: 21
            - exist-version: latest
+             java-version: 8
+           - exist-version: 7.0.0
              java-version: 8
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
        fail-fast: false
        matrix:
-         exist-version: [latest, 7.0.0, 6.0.0, release]
+        # created with 7.0.0-SNAPSHOT, 6.3.0
+         exist-version: [latest, 6.0.0, release]
          java-version: [8, 21]
          exclude:
            - exist-version: release
@@ -21,8 +22,6 @@ jobs:
            - exist-version: 6.0.0
              java-version: 21
            - exist-version: latest
-             java-version: 8
-           - exist-version: 7.0.0
              java-version: 8
 
     steps:

--- a/modules/get-icon.xq
+++ b/modules/get-icon.xq
@@ -22,7 +22,7 @@ return
         response:stream(doc($path), "media-type=" || xmldb:get-mime-type($path))
     (: png :)
     else if (util:binary-doc-available($path)) then
-        response:stream-binary(util:binary-doc($path), xmldb:get-mime-type($path))
+        response:stream-binary(util:binary-doc($path), xmldb:get-mime-type($path), $filename)
     else
         (
             response:set-status-code(404),

--- a/modules/get-package.xq
+++ b/modules/get-package.xq
@@ -6,6 +6,9 @@ xquery version "3.1";
  : Responds to requests like:
  : - /exist/apps/public-repo/public/eXide-1.0.0.xar
  : - /exist/apps/public-repo/public/eXide-1.0.0.xar.zip
+ :
+ : Uses response:stream-binary#3 for compatibility with both eXist 6.x and 7.x.
+ : See https://github.com/eXist-db/public-repo/issues/104
  :)
 
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
@@ -58,9 +61,9 @@ return
                 let $entry := <entry type="binary" method="store" name="/{$xar-filename}">{$xar}</entry>
                 let $zip := compression:zip($entry, false())
                 return
-                    response:stream-binary($zip, "application/zip")
+                    response:stream-binary($zip, "application/zip", $filename)
             else
-                response:stream-binary($xar, "application/zip")
+                response:stream-binary($xar, "application/zip", $xar-filename)
     else
         (
             response:set-status-code(404),


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

## Summary

- Closes #104. eXist 7.x removed the 2-argument arity of `response:stream-binary`; the 3-argument form (which adds a Content-Disposition filename) works on both 6.x and 7.x.
- Updates `modules/get-package.xq` and `modules/get-icon.xq` to pass the filename as the third argument.

## CI matrix note

An earlier commit added an explicit `7.0.0` slot to the matrix, but `duncdrum/existdb:7.0.0` doesn't exist yet (and `existdb/existdb` only publishes `7.0.0-SNAPSHOT`). Following peer precedent across the ecosystem — eXide, monex, dashboard, exist-markdown, function-documentation, documentation-next all rely on the floating `latest` tag rather than pinning explicit 7.x versions — that matrix change has been reverted. The current `latest` slot already covers eXist 7 via develop snapshots. Happy to adopt whatever pattern @duncdrum prefers for the registry/tag.

## Test plan
- [ ] CI green across the existing matrix (`latest`, `6.0.0`, `release`)
- [ ] Manually download a `.xar` and a `.png` icon from a 7.x-deployed instance and confirm `Content-Disposition` filename is preserved
- [ ] Confirm the existing 6.x flow still serves both file types correctly

## Notes

This PR is intentionally minimal — just the eXist 7 compatibility unblocker — so it can land ahead of the eXist 7 beta. Two follow-up PRs from the same `comprehensive-overhaul` work are queued:
1. Publish endpoint hardening (#133 versioned filenames + CSRF protection + migration script)
2. Broader overhaul (structured errors, accessibility, additional test infra, API enhancements, release CI)