### PR TITLE
build(ci): enable semantic-release + add npm wrapper scripts (Phase 6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,26 +80,32 @@ jobs:
           message: "chore(npm): bump vendor files [skip ci]"
           name: "eXist community bot"
 
-  # release:
-  #   name: Release
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   if: github.ref == 'refs/heads/master'
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v6 
-  #     - name: Setup Node.js
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         cache: npm  
-  #         node-version: lts/*
-  #     - name: Install dependencies
-  #       run: npm ci --no-optional   
-  #     - name: Perform Release
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         PUBLIC_REPO: ${{ secrets.PUBLIC_REPO }}
-  #       run: npx semantic-release
-        # TODO(DP): 
-        #   - add secrets to github
-        #   - publish to public repo?
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: lts/*
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - name: Install dependencies
+        run: npm ci --no-optional
+      - name: Build XAR
+        run: ant
+      - name: Perform Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLIC_REPO: ${{ secrets.PUBLIC_REPO }}
+        run: npx semantic-release
+        # NOTE: Requires GITHUB_TOKEN (automatic) and PUBLIC_REPO secrets to be configured
+        # in the repository settings by a repo admin.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,12 +100,9 @@ jobs:
           java-version: 21
       - name: Install dependencies
         run: npm ci --no-optional
-      - name: Build XAR
-        run: ant
       - name: Perform Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PUBLIC_REPO: ${{ secrets.PUBLIC_REPO }}
         run: npx semantic-release
-        # NOTE: Requires GITHUB_TOKEN (automatic) and PUBLIC_REPO secrets to be configured
-        # in the repository settings by a repo admin.
+        # semantic-release/exec runs `ant` as its publishCmd after computing
+        # the next version and writing it into package.json + build.properties.

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,6 +4,13 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "npm version ${nextRelease.version} --no-git-tag-version --allow-same-version && sed -i.bak 's/^project\\.version=.*/project.version=${nextRelease.version}/' build.properties && rm build.properties.bak",
+        "publishCmd": "ant"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "assets": [

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,18 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "build/*.xar",
+            "label": "EXPath Package (XAR)"
+          }
+        ]
+      }
+    ]
+  ]
+}

--- a/build.properties
+++ b/build.properties
@@ -4,4 +4,4 @@
 #
 
 project.name=public-repo
-project.version=4.1.1
+project.version=0.0.0-development

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,6 @@
     <property file="local.build.properties" />
     <property file="build.properties" />
     <property name="build" value="./build" />
-    <!-- <property name="server.url" value="http://exist-db.org/exist/apps/public-repo/publish"/> -->
     <condition property="git.commit" value="${git.commit}" else="">
         <isset property="git.commit" />
     </condition>
@@ -34,14 +33,12 @@
         </copy>
         <copy todir="resources/scripts" flatten="true" overwrite="true">
             <resources>
-                <!-- bootstrap -->
                 <file file="node_modules/bootstrap/dist/js/bootstrap.bundle.min.js" />
                 <file file="node_modules/bootstrap/dist/js/bootstrap.bundle.min.js.map" />
             </resources>
         </copy>
         <copy todir="resources/css" flatten="true" overwrite="true">
             <resources>
-                <!-- fileupload -->
                 <file file="node_modules/bootstrap/dist/css/bootstrap.min.css" />
                 <file file="node_modules/bootstrap/dist/css/bootstrap.min.css.map" />
             </resources>
@@ -64,15 +61,4 @@
             </fileset>
         </zip>
     </target>
-    <!--
-    <target name="upload">
-        <input message="Enter password:" addproperty="server.pass" defaultvalue="">
-            <handler type="secure"/>
-        </input>
-        <property name="xar" value="${project.name}-${project.version}${git.commit}.xar"/>
-        <exec executable="curl">
-            <arg line="-T ${build}/${xar} -u repo:${server.pass} ${server.url}/${xar}"/>
-        </exec>
-    </target>
-    -->
 </project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-repo",
-  "version": "4.1.1",
+  "version": "0.0.0-development",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "public-repo",
-      "version": "4.1.1",
+      "version": "0.0.0-development",
       "license": "LGPL-2.1-only",
       "dependencies": {
         "bootstrap": "^5.3.8"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "bootstrap": "^5.3.8"
   },
   "devDependencies": {
-    "cypress": "^15.14.2"
+    "cypress": "^15.15.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-repo",
-  "version": "4.1.1",
+  "version": "0.0.0-development",
   "description": "EXPath Package Repository",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
     "test": "test"
   },
   "scripts": {
+    "build": "ant",
+    "build:clean": "ant rebuild",
     "test": "npx cypress run",
-    "test:api": "node --test test/api/*.test.js"
+    "test:api": "node --test test/api/*.test.js",
+    "test:smoke": "bats test/bats/*.bats"
   },
   "repository": {
     "type": "git",
@@ -28,6 +31,6 @@
     "bootstrap": "^5.3.8"
   },
   "devDependencies": {
-    "cypress": "^15.15.0"
+    "cypress": "^15.14.2"
   }
 }


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

## Summary

Phase 6 of the `comprehensive-overhaul` work — modernize build and CI by enabling automated semantic-release.

- **`build.xml`** — Remove the dead `upload` target (already commented out, referenced a hardcoded `server.url`) and a few stale bookkeeping comments.
- **`package.json`** — Add `build`, `build:clean`, `test:smoke` npm scripts as thin wrappers (`test:api` was added in #152). Gives a uniform `npm run …` surface for dev workflow. Version pinned to `0.0.0-development` (see "Release pattern" below).
- **`build.properties`** — `project.version` pinned to `0.0.0-development` for the same reason.
- **`.releaserc.json`** (new) — semantic-release config attaching the built XAR to the GitHub release.
- **`.github/workflows/build.yml`** — Uncomment and update the release job (closes #97, partially #63). Runs after `build`, only on `master`.

## Release pattern (revised after community discussion)

The first revision of this PR used a hardcoded version in both `package.json` and `build.properties`. After @line-o's comment on [monex#386](https://github.com/eXist-db/monex/issues/386) and the discussion that produced the release-strategy proposal being shared with the devs, this PR is now aligned with the **no-push pattern** already used by `@existdb/xst`, `@existdb/node-exist`, and `@existdb/gulp-exist`, and adopted in [eXist-db/monex#396](https://github.com/eXist-db/monex/pull/396):

- `package.json` version pinned to `"0.0.0-development"` permanently on `master`.
- `build.properties` `project.version` pinned to `0.0.0-development` permanently on `master`.
- `.releaserc.json` uses `@semantic-release/exec` to set both files to `${nextRelease.version}` in-memory on the CI runner during the `prepare` phase, then runs `ant` via `publishCmd` so the built XAR carries the computed version.
- No `@semantic-release/git` plugin — nothing is pushed back to `master`, so branch protection works as intended and no PAT/App token is required.
- `@semantic-release/github` creates the tag + Release + uploads the XAR via the REST API.

After a release runs, `master`'s `package.json` and `build.properties` remain at `0.0.0-development`. The release history lives entirely in git tags + GitHub Releases.

## Removed in this revision

- The standalone `Build XAR` step in the release job — `ant` now runs as semantic-release/exec's `publishCmd` (so it sees the correct version).
- The `PUBLIC_REPO` env-var on the `Perform Release` step — vestigial from the prior commented-out stub; no current plugin reads it. Production-public-repo upload is out of scope here; see the release-strategy proposal §5.5 for the architectural options (recommended approach: a hub workflow that listens for `release.published` and uploads, rather than coupling each release pipeline to public-repo).

## Test plan

- [x] CI build job green across the full matrix
- [x] `npm run build` builds a XAR (with the dev placeholder version on local builds)
- [x] `npm run build:clean` runs `ant rebuild`
- [x] `npm run test:api` runs the Node test runner suites
- [x] `npm run test:smoke` runs bats (the docker-log smoke checks expect a container literally named `exist`, which CI provides — local runs without that container will see those 2 bats tests fail as expected)
- [x] Dry-run of the prepareCmd locally — `npm version X.Y.Z` updates `package.json`, and the sed snippet updates `build.properties` correctly
- [ ] After merge: confirm the `release` job runs on first push to `master` and successfully creates a GitHub release with the XAR attached (requires live merge; uses only `GITHUB_TOKEN`)

## Notes

This is the last of five PRs splitting up the long-dormant `comprehensive-overhaul` work:
- #151 — eXist 7 compat (response:stream-binary#3) ✅ merged
- #152 — Publish endpoint hardening (#133 versioned filenames + CSRF) ✅ merged
- #153 — Structured errors + custom 404 page + accessibility ✅ merged
- #154 — API enhancements (ETag/304, JSON, deps, UA classification) + Node test suites — open
- #155 — this PR (build/CI modernization)
