### PR TITLE
feat: improve logging

### DIFF
--- a/modules/find.xq
+++ b/modules/find.xq
@@ -65,23 +65,6 @@ declare function local:prefers-json($mime-types as xs:string*) as xs:boolean {
 
 declare variable $json-preferred := local:prefers-json(local:parse-accept-header());
 
-declare function local:log-find-event($package as element(package)?) as empty-sequence() {
-    if (exists($package)) then
-        (: /find is a public endpoint so the guest user may not have write permission to logs :)
-        try {
-            log:event(
-                element event {
-                    element dateTime { current-dateTime() },
-                    element type { "find-package" },
-                    element package-name { $package/name/string() },
-                    element package-version { $package/version/string() }
-                }
-            )
-        } catch * {
-            util:log("warn", "Could not log find event: " || $err:description)
-        }
-    else ()
-};
 
 declare function local:render-semver-range($semver as xs:string?, $semver-min as xs:string?, $semver-max as xs:string?) as xs:string {
     if (exists($semver)) then (
@@ -161,7 +144,7 @@ if (empty($packages)) then (
     local:report-not-found(
         ``[No matching version found for `{local:render-package-query()}`; `{local:render-version-query()}`.]``)
 ) else if ($info and $json-preferred) then (
-    local:log-find-event($package),
+    log:find-package-event($package),
     response:set-header("content-type", "application/json"),
     serialize(
         map {
@@ -176,7 +159,7 @@ if (empty($packages)) then (
         map { "method": "json" }
     )
 ) else if ($info) then (
-    local:log-find-event($package),
+    log:find-package-event($package),
     element found {
         $package/@sha256,
         $package/@path,
@@ -187,9 +170,9 @@ if (empty($packages)) then (
         attribute url { $abs-public || $package/@path }
     }
 ) else if ($zip) then (
-    local:log-find-event($package),
+    log:get-package-event($package),
     redirect:found($abs-public || $package/@path || ".zip")
 ) else (
-    local:log-find-event($package),
+    log:get-package-event($package),
     redirect:found($abs-public || $package/@path)
 )

--- a/modules/get-package.xq
+++ b/modules/get-package.xq
@@ -19,58 +19,38 @@ declare namespace request="http://exist-db.org/xquery/request";
 declare namespace response="http://exist-db.org/xquery/response";
 declare namespace util="http://exist-db.org/xquery/util";
 
-declare function local:log-get-package-event($filename as xs:string) as empty-sequence() {
-    let $package := doc($config:raw-packages-doc)//package[@path eq $filename]
-    let $event :=
-        element event {
-            element dateTime { current-dateTime() },
-            element type { "get-package" },
-            element package-name { $package/name/string() },
-            element package-version { $package/version/string() }
-        }
-    return
-        log:event($event)
-};
-
-declare function local:log-package-not-found-event($filename as xs:string) as empty-sequence() {
-    log:event(
-        element event {
-            element dateTime { current-dateTime() },
-            element type { "not-found" },
-            element file-name { $filename }
-        }
-    )
-};
-
 
 let $filename := request:get-parameter("filename", ())
 let $wants-zip as xs:boolean := ends-with($filename, ".zip")
 let $xar-filename :=
-    (: strip .zip from resource name :)
-    if ($wants-zip) then
+    if ($wants-zip) then (
+        (: strip .zip from resource name :)
         replace($filename, ".zip$", "")
-    else
+    ) else (
         $filename
+    )
 let $path := $config:packages-col || "/" || $xar-filename
+let $package := doc($config:raw-packages-doc)//package[@path eq $filename]
 return
-    if (util:binary-doc-available($path)) then
-        let $xar := util:binary-doc($config:packages-col || "/" || $xar-filename)
-        let $log := local:log-get-package-event($xar-filename)
-        return
-            if ($wants-zip) then
+    if (util:binary-doc-available($path) and exists($package)) then (
+        log:get-package-event($package),
+        let $xar := util:binary-doc($path)
+        return (
+            if ($wants-zip) then (
                 let $entry := <entry type="binary" method="store" name="/{$xar-filename}">{$xar}</entry>
                 let $zip := compression:zip($entry, false())
                 return
                     response:stream-binary($zip, "application/zip", $filename)
-            else
+            ) else (
                 response:stream-binary($xar, "application/zip", $xar-filename)
-    else
-        (
-            local:log-package-not-found-event($xar-filename),
-            response:set-status-code(404),
-            response:set-header("Content-Type", "application/xml"),
-            <error>
-                <status>404</status>
-                <message>Package file "{$xar-filename}" not found.</message>
-            </error>
+            )
         )
+    ) else (
+        log:package-not-found-event("Get Package by name """ || $xar-filename || """"),
+        response:set-status-code(404),
+        response:set-header("Content-Type", "application/xml"),
+        <error>
+            <status>404</status>
+            <message>Package file "{$xar-filename}" not found.</message>
+        </error>
+    )

--- a/modules/log.xqm
+++ b/modules/log.xqm
@@ -104,3 +104,36 @@ declare %private function log:collection($date as xs:date) as xs:string {
 declare %private function log:document-name($date as xs:date) as xs:string {
     "public-repo-log-" || format-date($date, "[Y]-[M01]-[D01]") || ".xml"
 };
+
+
+declare function log:get-package-event($package as element(package)) as empty-sequence() {
+    log:event(
+        element event {
+            element dateTime { current-dateTime() },
+            element type { "get-package" },
+            element package-name { $package/name/string() },
+            element package-version { $package/version/string() }
+        }
+    )
+};
+
+declare function log:find-package-event($package as element(package)) as empty-sequence() {
+    log:event(
+        element event {
+            element dateTime { current-dateTime() },
+            element type { "find-package" },
+            element package-name { $package/name/string() },
+            element package-version { $package/version/string() }
+        }
+    )
+};
+
+declare function log:package-not-found-event($query as xs:string) as empty-sequence() {
+    log:event(
+        element event {
+            element dateTime { current-dateTime() },
+            element type { "not-found" },
+            element query { $query }
+        }
+    )
+};

--- a/post-install.xq
+++ b/post-install.xq
@@ -77,5 +77,11 @@ if (doc-available($config:raw-packages-doc) and doc-available($config:package-gr
 else
     scanrepo:rebuild-all-package-metadata() ! sm:chown(xs:anyURI(.), config:repo-permissions()?owner),
 
-(: Ensure get-package.xq is run as "repo:repo", so that logs will always be writable :)
-sm:chmod(xs:anyURI($target || "/modules/get-package.xq"), "rwsr-sr-x")
+(: 
+ : Ensure that logs on public routes will always be written.
+ : Due to their nature being strictly read-only, they can run as "repo:repo".
+ : Making them non-writable, the module contents itself cannot be overwritten even by repo itself.
+ : get-package.xq, find.xq 
+ :)
+sm:chmod(xs:anyURI($target || "/modules/get-package.xq"), "r-sr-sr-x"),
+sm:chmod(xs:anyURI($target || "/modules/find.xq"), "r-sr-sr-x")


### PR DESCRIPTION
- replace try-catch by setgid in the same way already in place for get-packages.xq
- move event logging logic to log-module
   - `log:get-package-event` when a package is downloaded
   - `log:find-package-event` when a package is quried
   - `log:not-found-event` when a package could not be found
- the new logging functions are used in get-package.xq and find.xq replacing the module private functions
- improve get-package.xq
  - for readability
  - only allow download of packages that have metadata