### PR TITLE
fix(scan): serialize concurrent /publish, avoid lost-update on package-group

### DIFF
--- a/modules/scan.xqm
+++ b/modules/scan.xqm
@@ -154,8 +154,10 @@ function scanrepo:entry-filter($path as xs:anyURI, $type as xs:string, $param as
  :)
 declare
 (:    %private:)
-function scanrepo:generate-package-group($packages as element(package)*) {
-    if (count(distinct-values($packages/name)) gt 1) then
+function scanrepo:generate-package-group($packages as element(package)*) as element(package-group)? {
+    if (empty($packages)) then
+        ()
+    else if (count(distinct-values($packages/name)) gt 1) then
         error(QName("scanrepo", "group-error"), "Supplied packages do not have the same name")
     else
         (: Identify newest version of the package; sort previous versions newest to oldest; use SemVer 2.0 rules, coercing where needed :)
@@ -182,18 +184,37 @@ function scanrepo:generate-package-group($packages as element(package)*) {
 
 
 (:~
- : Update a package group, creating it if necessary
+ : Merge a newly-published <package> into its package-group, creating the
+ : group if it does not yet exist.
+ :
+ : The new package is combined directly with the existing group's other
+ : versions; raw-packages is not re-queried. That avoids two failure modes
+ : that surfaced under concurrent /publish calls:
+ :
+ : 1. XPTY0004 from semver:sort when the re-query returned the empty
+ :    sequence (because a sibling thread had not yet applied its own
+ :    pending update).
+ : 2. Lost-update: a group being overwritten with a stale set that did
+ :    not include another concurrent publish's contribution.
+ :
+ : Concurrent invocations are still serialized at the publish-package
+ : entry point via util:exclusive-lock; this function is correct in
+ : isolation, the lock protects the publish operation end-to-end.
+ :
+ : @see https://github.com/eXist-db/public-repo/issues/{TBD}
  :)
-declare function scanrepo:update-package-group($raw-package-name as xs:string) {
-    let $raw-packages := doc($config:raw-packages-doc)/raw-packages
-    let $raw-packages-to-group := $raw-packages/package[name = $raw-package-name]
+declare function scanrepo:update-package-group($new-package as element(package)) {
+    let $name := $new-package/name/string()
     let $package-groups := doc($config:package-groups-doc)/package-groups
-    let $current-package-group := $package-groups/package-group[name eq $raw-package-name]
+    let $current-group := $package-groups/package-group[name eq $name]
+    (: Replace any same-path entry in the existing group; merge with the rest. :)
+    let $other-versions := $current-group/packages/package[not(@path eq $new-package/@path)]
+    let $merged := scanrepo:generate-package-group(($new-package, $other-versions))
     return
-        if (exists($current-package-group)) then
-            update replace $current-package-group with scanrepo:generate-package-group($raw-packages-to-group)
+        if (exists($current-group)) then
+            update replace $current-group with $merged
         else
-            update insert scanrepo:generate-package-group($raw-packages-to-group) into $package-groups
+            update insert $merged into $package-groups
 };
 
 (:~
@@ -233,14 +254,25 @@ declare function scanrepo:extract-raw-package($xar-filename as xs:string) as ele
 };
 
 (:~
- : Publish a stored package by adding it to the raw-packages and package-groups metadata
+ : Publish a stored package by adding it to the raw-packages and package-groups metadata.
+ :
+ : Concurrent invocations are serialized on the package-groups document via
+ : util:exclusive-lock. Without serialization, two parallel /publish calls
+ : can interleave such that one thread's update-package-group reads the
+ : metadata state before another thread's add-raw-package has been applied,
+ : producing either a 500 (XPTY0004 in semver:sort on an empty package set)
+ : or a lost-update that leaves the package-group missing one of the
+ : concurrent uploads.
  :)
 declare function scanrepo:publish-package($xar-filename as xs:string) {
     let $package := scanrepo:extract-raw-package($xar-filename)
     return
-        (
-            scanrepo:add-raw-package($package),
-            scanrepo:update-package-group($package/name)
+        util:exclusive-lock(
+            doc($config:package-groups-doc),
+            (
+                scanrepo:add-raw-package($package),
+                scanrepo:update-package-group($package)
+            )
         )
 };
 


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

## Summary

Concurrent `/publish` requests against the public-repo cause intermittent **500 errors on upload** and **404 errors on `/find`**, because `scanrepo:publish-package` is not race-safe. On a fresh `duncdrum/existdb:6.0.0` container running `npm run test:api` repeatedly, master fails ~73% of the time (11/15 in a representative sample); with this fix, 50/50 pass.

This is also the root cause of the master CI flake first surfaced in run [26595362801](https://github.com/eXist-db/public-repo/actions/runs/26595362801) (post-#162 merge) — both the `find.test.js > processor version matching > processor 5.0.0 / 7.0.0` failures and the `publish.test.js > test-lib.xar upload` failures trace back to the same race.

## Root cause walkthrough

`scanrepo:publish-package` does an `add-raw-package` followed by an `update-package-group`. `update-package-group` re-queries `raw-packages.xml` to compute the new group:

```xquery
let $raw-packages-to-group := $raw-packages/package[name = $raw-package-name]
...
update replace $current-package-group with scanrepo:generate-package-group($raw-packages-to-group)
```

Under concurrent uploads, two failure modes appear:

1. **500 on upload.** Thread B reads `raw-packages.xml` after Thread A's `add-raw-package` has applied but before Thread B's own has. The XPath filter returns the empty sequence, `generate-package-group(())` invokes `semver:sort(())`, and `semver:sort` (typed `($versions as xs:string+)`) throws **XPTY0004**. The publish endpoint's catch block surfaces this as 500.

2. **404 from `/find`.** A milder version of the same window: `update-package-group` recomputes a group from a stale read and `update replace`s an existing group with one that's missing a sibling thread's contribution. The package disappears from the package-group even though it's on disk and in `raw-packages`.

Captured 500 response body from local repro:

```
exerr:ERROR XPTY0004: ... semver:sort($versions as xs:string+).
Expected cardinality: one or more, got 0.
  semver:sort(xs:string+) [.../semver-xq-3.0.0/content/semver.xqm]
  scanrepo:generate-package-group(element(package)*) [scan.xqm:194]
  scanrepo:update-package-group(xs:string) [scan.xqm:243]
  scanrepo:publish-package(xs:string) [scan.xqm:42]
```

## Fix

Three changes in `modules/scan.xqm`:

1. **`scanrepo:generate-package-group` returns `()` for empty input** (signature: `as element(package-group)?`). Defense-in-depth: never let `semver:sort` see the empty sequence.

2. **`scanrepo:update-package-group` takes the new `element(package)` directly** rather than a name string. It reads the existing group's other versions in place and merges with the new package, without re-querying `raw-packages.xml`. Closes the pending-update-visibility window.

3. **`scanrepo:publish-package` wraps the add+update in `util:exclusive-lock(doc($config:package-groups-doc), ...)`** so concurrent invocations serialize on the package-groups document. Reads/writes are consistent end-to-end and the lost-update mode also goes away.

## Local verification

Both versions tested in fresh containers (logs + metadata wiped between iterations):

| Container | `npm run test:api` (50 iter) | `npx cypress run` |
|---|---|---|
| `duncdrum/existdb:6.0.0` (master) | 11/15 fail (~73%) | n/a |
| `duncdrum/existdb:6.0.0` (this PR) | **50/50 pass** | **All 24 specs pass** |
| local eXist 7 (this PR) | 49/50 pass on first big sweep; 20/20 on tighter retest | **All 24 specs pass** |

The residual single-iteration flake on eXist 7 is much rarer than the master rate and may be a different root cause; happy to look at it as a follow-up if it recurs.

## Notes

- The matching cypress `stats_spec.cy.js > authorized user should be able to see statistics` h1-not-found failure that appeared on the same master CI run traced to a **separate** bug: pre-#163 `get-package.xq` logged events for binaries-with-no-raw-packages-entry, producing empty `<package-name/>` events. `app:package-stats-item` then looked up `package-group[name = ""]` → empty → `packages:render-list-item(())` threw XPTY0004 → no `<h1>` rendered. PR #163 already fixed the underlying logging bug; this PR doesn't need to address it.
- `scanrepo:rebuild-package-groups` is unaffected — it uses `xmldb:store` (full-doc rewrite) and always groups non-empty input.

## Test plan

- [ ] CI green across the full matrix (`latest`, `6.0.0`, `release`)
- [ ] Manually run `npm run test:api` 10× against a freshly-deployed XAR — expect zero flakes